### PR TITLE
fix: Cursor PrimaryKey reflection

### DIFF
--- a/cursor/cursor.go
+++ b/cursor/cursor.go
@@ -12,7 +12,7 @@ func Create[T any](row *T, fields []string, primaryKey string) (string, error) {
 
 	if len(fields) == 0 {
 		return utils.MapToBase64(map[string]any{
-			primaryKey: reflectRow.FieldByNameFunc(fieldWithColumnIsEqual(primaryKey)).String(),
+			primaryKey: reflectRow.FieldByNameFunc(fieldWithColumnIsEqual(primaryKey)).Interface(),
 		})
 	}
 


### PR DESCRIPTION
Hello,

I would like to propose a pull request for fixing a bug related to the cursor creation function. The bug occurs when the primary field is [Google UUID](https://github.com/google/uuid) and the order by clause is not defined. In this case, the Reflection.String() method always returns "<uuid.UUID Value>", which causes the result base64 values to be identical.

<img width="921" alt="image" src="https://github.com/cloudmatelabs/gorm-gqlgen-relay/assets/16222645/5962a2cc-5e2f-43be-882a-9b4e7e207530">


![image](https://github.com/cloudmatelabs/gorm-gqlgen-relay/assets/16222645/31df7e87-b5ba-4c3d-8ab4-5d87f1b1fb03)

I appreciate your feedback and review of this pull request.
