### PR TITLE
feature: Add `TablePrefix` in relay paginite options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,16 @@ func (r *queryResolver) Todos(ctx context.Context, first *int, after *string, la
 	db := context.Database.Preload("User")
 
 	return relay.Paginate[model.Todo](db, where, orderBy, relay.PaginateOption{
-		First:      first,
-		After:      after,
-		Last:       last,
-		Before:     before,
-		Table:      "todos",
+		First:       first,
+		After:       after,
+		Last:        last,
+		Before:      before,
+    // Like postgres schema, mysql db, mssql schema, etc...
+    TablePrefix: "public",
+		Table:       "todos",
     // If you using joins table
-    // Tables:   &map[string]string{"id": "todos", "user_id": "users"},
-		PrimaryKey: "id", // or "todos.id"
+    // Tables:    &map[string]string{"id": "todos", "user_id": "users"},
+		PrimaryKey:  "id", // or "todos.id"
 	})
 }
 ```
@@ -130,6 +132,7 @@ package main
 | Last | int | The number of reversed items to return |
 | After | string | A cursor for use in pagination, which is a base-64 encoded string that points to a specific page in the dataset. |
 | Before | string | A cursor for use in pagination, which is a base-64 encoded string that points to a specific page in the dataset. |
+| TablePrefix | string | Schema(or DB) name (optional) |
 | Table | string | Table name (optional) |
 | Tables | *map[string]string | Table names (optional) |
 | PrimaryKey | string | Primary key name (optional) |

--- a/cursor/after_before_test.go
+++ b/cursor/after_before_test.go
@@ -21,8 +21,8 @@ func TestAfter(t *testing.T) {
 		t.Error("Expected 1 argument")
 	}
 
-	if queries[0] != "id > ?" {
-		t.Error("Expected id > ?, got", queries[0])
+	if queries[0] != "\"id\" > ?" {
+		t.Error("Expected \"id\" > ?, got", queries[0])
 	}
 
 	if args[0] != "1" {
@@ -45,8 +45,8 @@ func TestBefore(t *testing.T) {
 		t.Error("Expected 1 argument")
 	}
 
-	if queries[0] != "id > ?" {
-		t.Error("Expected id > ?, got", queries[0])
+	if queries[0] != "\"id\" > ?" {
+		t.Error("Expected \"id\" > ?, got", queries[0])
 	}
 
 	if args[0] != "1" {

--- a/order/order_test.go
+++ b/order/order_test.go
@@ -25,12 +25,12 @@ func TestOrder(t *testing.T) {
 		t.Fatal("query length should be 2")
 	}
 
-	if !slices.Contains(query, "sample.field1 ASC") {
-		t.Fatal("query should contain sample.field1 ASC")
+	if !slices.Contains(query, "\"sample\".\"field1\" ASC") {
+		t.Fatal("query should contain \"sample\".\"field1\" ASC", "\nactual:", query)
 	}
 
-	if !slices.Contains(query, "sample.field2 DESC") {
-		t.Fatal("query should contain sample.field2 DESC")
+	if !slices.Contains(query, "\"sample\".\"field2\" DESC") {
+		t.Fatal("query should contain \"sample\".\"field2\" DESC", "\nactual:", query)
 	}
 }
 
@@ -44,12 +44,12 @@ func TestReverseOrder(t *testing.T) {
 		t.Fatal("query length should be 2")
 	}
 
-	if !slices.Contains(query, "field1 DESC") {
-		t.Fatal("query should contain field1 DESC")
+	if !slices.Contains(query, "\"field1\" DESC") {
+		t.Fatal("query should contain \"field1\" DESC", "\nactual:", query)
 	}
 
-	if !slices.Contains(query, "field2 ASC") {
-		t.Fatal("query should contain field2 ASC")
+	if !slices.Contains(query, "\"field2\" ASC") {
+		t.Fatal("query should contain \"field2\" ASC", "\nactual:", query)
 	}
 }
 
@@ -63,11 +63,11 @@ func TestOrder_With_Tables(t *testing.T) {
 		t.Fatal("query length should be 2")
 	}
 
-	if !slices.Contains(query, "sample.field1 ASC") {
-		t.Fatal("query should contain sample.field1 ASC")
+	if !slices.Contains(query, "\"sample\".\"field1\" ASC") {
+		t.Fatal("query should contain \"sample\".\"field1\" ASC")
 	}
 
-	if !slices.Contains(query, "field2 DESC") {
-		t.Fatal("query should contain field2 DESC")
+	if !slices.Contains(query, "\"field2\" DESC") {
+		t.Fatal("query should contain \"field2\" DESC")
 	}
 }

--- a/relay/paginate.go
+++ b/relay/paginate.go
@@ -12,6 +12,7 @@ type PaginateOption struct {
 	Last       *int
 	After      *string
 	Before     *string
+	Prefix     *string
 	Table      string
 	Tables     *map[string]string
 	PrimaryKey string
@@ -22,7 +23,7 @@ func Paginate[Model any](db *gorm.DB, _where any, _orderBy any, option PaginateO
 		return nil, err
 	}
 
-	w, err := where.Do(db.Dialector.Name(), option.Table, option.Tables, _where)
+	w, err := where.Do(db.Dialector.Name(), option.Table, option.Tables, option.Prefix, _where)
 	if err != nil {
 		return nil, err
 	}

--- a/where/traverse.go
+++ b/where/traverse.go
@@ -25,7 +25,7 @@ func Traverse(db *gorm.DB, where Where) *gorm.DB {
 	return stmt
 }
 
-func traverse(dialector, table string, tables *map[string]string, input map[string]any) (where Where) {
+func traverse(dialector, table string, tables *map[string]string, schema *string, input map[string]any) (where Where) {
 	for key, value := range input {
 		if value == nil {
 			continue
@@ -33,33 +33,41 @@ func traverse(dialector, table string, tables *map[string]string, input map[stri
 
 		if key == "and" {
 			for _, v := range value.([]any) {
-				where.And = append(where.And, traverse(dialector, table, tables, v.(map[string]any)))
+				where.And = append(where.And, traverse(dialector, table, tables, schema, v.(map[string]any)))
 			}
 			continue
 		}
 
 		if key == "or" {
 			for _, v := range value.([]any) {
-				where.Or = append(where.Or, traverse(dialector, table, tables, v.(map[string]any)))
+				where.Or = append(where.Or, traverse(dialector, table, tables, schema, v.(map[string]any)))
 			}
 			continue
 		}
 
 		if key == "not" {
-			where.Not = utils.ToPointer(traverse(dialector, table, tables, value.(map[string]any)))
+			where.Not = utils.ToPointer(traverse(dialector, table, tables, schema, value.(map[string]any)))
 			continue
 		}
 
 		prefix := ""
 
 		if table != "" {
-			prefix = "\"" + table + "\"" + "."
+			if schema != nil {
+				prefix = "\"" + *schema + "\"."
+			}
+
+			prefix += "\"" + table + "\"" + "."
 		}
 
 		if tables != nil {
 			for k, v := range *tables {
 				if k == key {
-					prefix = "\"" + v + "\"" + "."
+					if schema != nil {
+						prefix = "\"" + *schema + "\"."
+					}
+
+					prefix += "\"" + v + "\"" + "."
 					break
 				}
 			}

--- a/where/where.go
+++ b/where/where.go
@@ -11,11 +11,11 @@ type Where struct {
 	Args  []any
 }
 
-func Do(dialector, table string, tables *map[string]string, input any) (Where, error) {
+func Do(dialector, table string, tables *map[string]string, schema *string, input any) (Where, error) {
 	filter, err := utils.ConvertToMap(input)
 	if err != nil {
 		return Where{}, err
 	}
 
-	return traverse(dialector, table, tables, filter), nil
+	return traverse(dialector, table, tables, schema, filter), nil
 }

--- a/where/where_test.go
+++ b/where/where_test.go
@@ -43,7 +43,7 @@ func TestWhereWithTable(t *testing.T) {
 		t.Error(err)
 	}
 
-	if filter.And[0].Query != "test.title = ?" {
+	if filter.And[0].Query != "\"test\".\"title\" = ?" {
 		t.Errorf("query is not correct: '%s'", filter.And[0].Query)
 	}
 
@@ -51,7 +51,7 @@ func TestWhereWithTable(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.And[0].Args[0])
 	}
 
-	if filter.Or[0].Query != "test.title = ?" {
+	if filter.Or[0].Query != "\"test\".\"title\" = ?" {
 		t.Errorf("query is not correct: '%s'", filter.Or[0].Query)
 	}
 
@@ -59,7 +59,7 @@ func TestWhereWithTable(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.Or[0].Args[0])
 	}
 
-	if filter.Or[0].Not.Query != "test.title = ?" {
+	if filter.Or[0].Not.Query != "\"test\".\"title\" = ?" {
 		t.Errorf("query is not correct: '%s'", filter.Or[0].Not.Query)
 	}
 
@@ -67,8 +67,8 @@ func TestWhereWithTable(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.Or[0].Not.Args[0])
 	}
 
-	if !(filter.Query == "test.title = ? AND test.title IS NULL" ||
-		filter.Query == "test.title IS NULL AND test.title = ?") {
+	if !(filter.Query == "\"test\".\"title\" = ? AND \"test\".\"title\" IS NULL" ||
+		filter.Query == "\"test\".\"title\" IS NULL AND \"test\".\"title\" = ?") {
 		t.Errorf("query is not correct: '%s'", filter.Query)
 	}
 
@@ -83,7 +83,7 @@ func TestWhereWithTables(t *testing.T) {
 		t.Error(err)
 	}
 
-	if filter.And[0].Query != "sample.title = ?" {
+	if filter.And[0].Query != "\"sample\".\"title\" = ?" {
 		t.Errorf("query is not correct: '%s'", filter.And[0].Query)
 	}
 
@@ -91,7 +91,7 @@ func TestWhereWithTables(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.And[0].Args[0])
 	}
 
-	if filter.Or[0].Query != "sample.title = ?" {
+	if filter.Or[0].Query != "\"sample\".\"title\" = ?" {
 		t.Errorf("query is not correct: '%s'", filter.Or[0].Query)
 	}
 
@@ -99,7 +99,7 @@ func TestWhereWithTables(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.Or[0].Args[0])
 	}
 
-	if filter.Or[0].Not.Query != "sample.title = ?" {
+	if filter.Or[0].Not.Query != "\"sample\".\"title\" = ?" {
 		t.Errorf("query is not correct: '%s'", filter.Or[0].Not.Query)
 	}
 
@@ -107,8 +107,8 @@ func TestWhereWithTables(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.Or[0].Not.Args[0])
 	}
 
-	if !(filter.Query == "sample.title = ? AND sample.title IS NULL" ||
-		filter.Query == "sample.title IS NULL AND sample.title = ?") {
+	if !(filter.Query == "\"sample\".\"title\" = ? AND \"sample\".\"title\" IS NULL" ||
+		filter.Query == "\"sample\".\"title\" IS NULL AND \"sample\".\"title\" = ?") {
 		t.Errorf("query is not correct: '%s'", filter.Query)
 	}
 
@@ -123,7 +123,7 @@ func TestWhereWithTablesWhenNoMatchesColumns(t *testing.T) {
 		t.Error(err)
 	}
 
-	if filter.And[0].Query != "title = ?" {
+	if filter.And[0].Query != "\"title\" = ?" {
 		t.Errorf("query is not correct: '%s'", filter.And[0].Query)
 	}
 
@@ -131,7 +131,7 @@ func TestWhereWithTablesWhenNoMatchesColumns(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.And[0].Args[0])
 	}
 
-	if filter.Or[0].Query != "title = ?" {
+	if filter.Or[0].Query != "\"title\" = ?" {
 		t.Errorf("query is not correct: '%s'", filter.Or[0].Query)
 	}
 
@@ -139,7 +139,7 @@ func TestWhereWithTablesWhenNoMatchesColumns(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.Or[0].Args[0])
 	}
 
-	if filter.Or[0].Not.Query != "title = ?" {
+	if filter.Or[0].Not.Query != "\"title\" = ?" {
 		t.Errorf("query is not correct: '%s'", filter.Or[0].Not.Query)
 	}
 
@@ -147,8 +147,8 @@ func TestWhereWithTablesWhenNoMatchesColumns(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.Or[0].Not.Args[0])
 	}
 
-	if !(filter.Query == "title = ? AND title IS NULL" ||
-		filter.Query == "title IS NULL AND title = ?") {
+	if !(filter.Query == "\"title\" = ? AND \"title\" IS NULL" ||
+		filter.Query == "\"title\" IS NULL AND \"title\" = ?") {
 		t.Errorf("query is not correct: '%s'", filter.Query)
 	}
 

--- a/where/where_test.go
+++ b/where/where_test.go
@@ -3,6 +3,7 @@ package where_test
 import (
 	"testing"
 
+	"github.com/cloudmatelabs/gorm-gqlgen-relay/utils"
 	"github.com/cloudmatelabs/gorm-gqlgen-relay/where"
 )
 
@@ -38,12 +39,12 @@ var query = map[string]any{
 }
 
 func TestWhereWithTable(t *testing.T) {
-	filter, err := where.Do("mysql", "test", nil, query)
+	filter, err := where.Do("postgres", "test", nil, nil, query)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if filter.And[0].Query != "\"test\".\"title\" = ?" {
+	if filter.And[0].Query != `"test"."title" = ?` {
 		t.Errorf("query is not correct: '%s'", filter.And[0].Query)
 	}
 
@@ -51,7 +52,7 @@ func TestWhereWithTable(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.And[0].Args[0])
 	}
 
-	if filter.Or[0].Query != "\"test\".\"title\" = ?" {
+	if filter.Or[0].Query != `"test"."title" = ?` {
 		t.Errorf("query is not correct: '%s'", filter.Or[0].Query)
 	}
 
@@ -59,7 +60,7 @@ func TestWhereWithTable(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.Or[0].Args[0])
 	}
 
-	if filter.Or[0].Not.Query != "\"test\".\"title\" = ?" {
+	if filter.Or[0].Not.Query != `"test"."title" = ?` {
 		t.Errorf("query is not correct: '%s'", filter.Or[0].Not.Query)
 	}
 
@@ -67,8 +68,8 @@ func TestWhereWithTable(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.Or[0].Not.Args[0])
 	}
 
-	if !(filter.Query == "\"test\".\"title\" = ? AND \"test\".\"title\" IS NULL" ||
-		filter.Query == "\"test\".\"title\" IS NULL AND \"test\".\"title\" = ?") {
+	if !(filter.Query == `"test"."title" = ? AND "test"."title" IS NULL` ||
+		filter.Query == `"test"."title" IS NULL AND "test"."title" = ?`) {
 		t.Errorf("query is not correct: '%s'", filter.Query)
 	}
 
@@ -78,12 +79,12 @@ func TestWhereWithTable(t *testing.T) {
 }
 
 func TestWhereWithTables(t *testing.T) {
-	filter, err := where.Do("mysql", "", &map[string]string{"title": "sample"}, query)
+	filter, err := where.Do("postgres", "", &map[string]string{"title": "sample"}, nil, query)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if filter.And[0].Query != "\"sample\".\"title\" = ?" {
+	if filter.And[0].Query != `"sample"."title" = ?` {
 		t.Errorf("query is not correct: '%s'", filter.And[0].Query)
 	}
 
@@ -91,7 +92,7 @@ func TestWhereWithTables(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.And[0].Args[0])
 	}
 
-	if filter.Or[0].Query != "\"sample\".\"title\" = ?" {
+	if filter.Or[0].Query != `"sample"."title" = ?` {
 		t.Errorf("query is not correct: '%s'", filter.Or[0].Query)
 	}
 
@@ -99,7 +100,7 @@ func TestWhereWithTables(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.Or[0].Args[0])
 	}
 
-	if filter.Or[0].Not.Query != "\"sample\".\"title\" = ?" {
+	if filter.Or[0].Not.Query != `"sample"."title" = ?` {
 		t.Errorf("query is not correct: '%s'", filter.Or[0].Not.Query)
 	}
 
@@ -107,8 +108,8 @@ func TestWhereWithTables(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.Or[0].Not.Args[0])
 	}
 
-	if !(filter.Query == "\"sample\".\"title\" = ? AND \"sample\".\"title\" IS NULL" ||
-		filter.Query == "\"sample\".\"title\" IS NULL AND \"sample\".\"title\" = ?") {
+	if !(filter.Query == `"sample"."title" = ? AND "sample"."title" IS NULL` ||
+		filter.Query == `"sample"."title" IS NULL AND "sample"."title" = ?`) {
 		t.Errorf("query is not correct: '%s'", filter.Query)
 	}
 
@@ -118,12 +119,12 @@ func TestWhereWithTables(t *testing.T) {
 }
 
 func TestWhereWithTablesWhenNoMatchesColumns(t *testing.T) {
-	filter, err := where.Do("mysql", "", &map[string]string{"created_at": "sample"}, query)
+	filter, err := where.Do("postgres", "", &map[string]string{"created_at": "sample"}, nil, query)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if filter.And[0].Query != "\"title\" = ?" {
+	if filter.And[0].Query != `"title" = ?` {
 		t.Errorf("query is not correct: '%s'", filter.And[0].Query)
 	}
 
@@ -131,7 +132,7 @@ func TestWhereWithTablesWhenNoMatchesColumns(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.And[0].Args[0])
 	}
 
-	if filter.Or[0].Query != "\"title\" = ?" {
+	if filter.Or[0].Query != `"title" = ?` {
 		t.Errorf("query is not correct: '%s'", filter.Or[0].Query)
 	}
 
@@ -139,7 +140,7 @@ func TestWhereWithTablesWhenNoMatchesColumns(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.Or[0].Args[0])
 	}
 
-	if filter.Or[0].Not.Query != "\"title\" = ?" {
+	if filter.Or[0].Not.Query != `"title" = ?` {
 		t.Errorf("query is not correct: '%s'", filter.Or[0].Not.Query)
 	}
 
@@ -147,8 +148,48 @@ func TestWhereWithTablesWhenNoMatchesColumns(t *testing.T) {
 		t.Errorf("args is not correct: '%s'", filter.Or[0].Not.Args[0])
 	}
 
-	if !(filter.Query == "\"title\" = ? AND \"title\" IS NULL" ||
-		filter.Query == "\"title\" IS NULL AND \"title\" = ?") {
+	if !(filter.Query == `"title" = ? AND "title" IS NULL` ||
+		filter.Query == `"title" IS NULL AND "title" = ?`) {
+		t.Errorf("query is not correct: '%s'", filter.Query)
+	}
+
+	if filter.Args[0] != "Hello World" {
+		t.Errorf("args is not correct: '%s'", filter.Args[0])
+	}
+}
+
+func TestWhereWithTableAndPrefix(t *testing.T) {
+	filter, err := where.Do("postgres", "test", nil, utils.ToPointer("dev"), query)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if filter.And[0].Query != `"dev"."test"."title" = ?` {
+		t.Errorf("query is not correct: '%s'", filter.And[0].Query)
+	}
+
+	if filter.And[0].Args[0] != "Hello World" {
+		t.Errorf("args is not correct: '%s'", filter.And[0].Args[0])
+	}
+
+	if filter.Or[0].Query != `"dev"."test"."title" = ?` {
+		t.Errorf("query is not correct: '%s'", filter.Or[0].Query)
+	}
+
+	if filter.Or[0].Args[0] != "Hello World" {
+		t.Errorf("args is not correct: '%s'", filter.Or[0].Args[0])
+	}
+
+	if filter.Or[0].Not.Query != `"dev"."test"."title" = ?` {
+		t.Errorf("query is not correct: '%s'", filter.Or[0].Not.Query)
+	}
+
+	if filter.Or[0].Not.Args[0] != "Hello World" {
+		t.Errorf("args is not correct: '%s'", filter.Or[0].Not.Args[0])
+	}
+
+	if !(filter.Query == `"dev"."test"."title" = ? AND "dev"."test"."title" IS NULL` ||
+		filter.Query == `"dev"."test"."title" IS NULL AND "dev"."test"."title" = ?`) {
 		t.Errorf("query is not correct: '%s'", filter.Query)
 	}
 


### PR DESCRIPTION
Requested by #4 

- Add `TablePrefix` property in `relay.PaginateOption`
- `TablePrefix` is postgres schema or mssql schema or mysql db, etc...